### PR TITLE
添加云原生社区信息

### DIFF
--- a/docs/book/theme/header.hbs
+++ b/docs/book/theme/header.hbs
@@ -1,5 +1,4 @@
 <header id="notice-bar">
-    <h2>kubebuilder 官方文档中文翻译正在招募译者中，欢迎踊跃报名。</h2>
-    <p>详情请看 <a href="https://github.com/cloudnativeto/community/issues/21">这里</a>和<a href="https://github.com/cloudnativeto/kubebuilder/tree/zh/docs/book">翻译流程</a>。</p>
+    <h2>kubebuilder 中文文档由<a href="https://cloudnative.to/">云原生社区</a>主导翻译。任何问题可以在<a href="https://github.com/cloudnativeto/kubebuilder/issues">这儿</a>提issue。
     </p>
 </header>


### PR DESCRIPTION
在页面头部添加云原生社区信息，表明是云原生社区翻译。